### PR TITLE
Git documentation: Miscellaneous page

### DIFF
--- a/Tools/Git/6 Misc.md
+++ b/Tools/Git/6 Misc.md
@@ -5,6 +5,7 @@
 ## Contents
 
 - [Get Current Branch Name](#get-current-branch-name)
+- [Get Tracking Branch](#get-tracking-branch)
 
 ### Get Current Branch Name
 
@@ -20,3 +21,26 @@ git rev-parse --abbrev-ref HEAD
 ```
 
 *Source: [Stack Overflow](http://stackoverflow.com/a/1418022)*
+
+### Get Tracking Branch
+
+The tracking branch (or upstream branch) of all checked out branches can be displayed using
+[`git branch -vv`](3 Commands.md#git-branch). If scripting Git commands, this output is very noisy
+and requires extra effort to pick out the tracking branch from the current branch.
+
+Instead, the following command can be used to return the current branch's tracking branch, in the
+format `upstream/branch`:
+
+```
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+If there is no tracking branch an error is displayed and the process exits with error code 128. This
+can be avoided by instead running the following command which outputs an empty line instead of an
+error:
+
+```
+git for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)
+```
+
+*Source: [Stack Overflow](http://stackoverflow.com/a/9753364)*

--- a/Tools/Git/6 Misc.md
+++ b/Tools/Git/6 Misc.md
@@ -1,0 +1,22 @@
+# Git: Miscellaneous
+
+*Very specific, less useful documentation about Git. Essentially a scrapbook of everything else.*
+
+## Contents
+
+- [Get Current Branch Name](#get-current-branch-name)
+
+### Get Current Branch Name
+
+The currently checked out branch name can be displayed using
+[`git branch`](3 Commands.md#git-branch). If scripting Git commands, this output is noisy and
+requires extra effort to pick out the current branch.
+
+Instead, the following command can be used to return the name of the current branch and nothing
+else:
+
+```
+git rev-parse --abbrev-ref HEAD
+```
+
+*Source: [Stack Overflow](http://stackoverflow.com/a/1418022)*

--- a/Tools/Git/README.md
+++ b/Tools/Git/README.md
@@ -9,4 +9,4 @@ http://git-scm.com/
 3. [Commands](3 Commands.md)
 4. [Processes](4 Processes.md)
 5. [Frequently Asked Questions](5 FAQ.md)
-6. [Misc](6 Misc.md)
+6. [Miscellaneous](6 Misc.md)

--- a/Tools/Git/README.md
+++ b/Tools/Git/README.md
@@ -9,3 +9,4 @@ http://git-scm.com/
 3. [Commands](3 Commands.md)
 4. [Processes](4 Processes.md)
 5. [Frequently Asked Questions](5 FAQ.md)
+6. [Misc](6 Misc.md)


### PR DESCRIPTION
Added the last dregs of my Git notes from the deepest darkest recesses of my files.
Covers some obscure commands that might be useful for scripting.

As this has been created under a "Miscellaneous" page, this also provided somewhere to throw any more documentation that doesn't fit in the other Git pages neatly.